### PR TITLE
fix: add CONNECTOR_AUTOLOAD_PEERS to true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       LEDGER_RECOMMENDED_CONNECTORS: "connector"
       CONNECTOR_ENABLE: "true"
       CONNECTOR_AUTOLOAD_PEERS: "true"
+      CONNECTOR_MAX_HOLD_TIME: "100"
       CONNECTOR_LEDGERS: '{"g.dev.${ILP_DOMAIN}.":{"currency":"${ILP_CURRENCY}","plugin":"ilp-plugin-bells","options":{"account":"https://${ILP_DOMAIN}/ledger/accounts/connector","username":"connector","password":"${ILP_SECRET}"}}}'
       API_REGISTRATION: "true"
       LEDGER_AMOUNT_SCALE: "9"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       LEDGER_ILP_PREFIX: "g.dev.${ILP_DOMAIN}."
       LEDGER_RECOMMENDED_CONNECTORS: "connector"
       CONNECTOR_ENABLE: "true"
+      CONNECTOR_AUTOLOAD_PEERS: "true"
       CONNECTOR_LEDGERS: '{"g.dev.${ILP_DOMAIN}.":{"currency":"${ILP_CURRENCY}","plugin":"ilp-plugin-bells","options":{"account":"https://${ILP_DOMAIN}/ledger/accounts/connector","username":"connector","password":"${ILP_SECRET}"}}}'
       API_REGISTRATION: "true"
       LEDGER_AMOUNT_SCALE: "9"


### PR DESCRIPTION
This variable defaults to true in ilp-kit-cli, but to false in ilp-connector, that's why it needs to be added here explicitly.
The app.json (for heroku deploy), and dev/test env.list also all have it like this.